### PR TITLE
update readme to clarify the merge function

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status][travis-image]][travis-url]
 [![Test Coverage][coveralls-image]][coveralls-url]
 
-Merge objects using descriptors.
+Merge source object properties onto a destination object, and preserve descriptors.  Descriptors are configuration data associated to each property such as whether the property is `writable`, `enumerable`, and/or `configurable`.  This data will be preserved in the destination object.
 
 ```js
 var thing = {
@@ -25,15 +25,9 @@ animal.name === 'jon'
 
 ## API
 
-### merge(destination, source)
+### merge(Object destination, Object source [, bool overwrite])
 
-Redefines `destination`'s descriptors with `source`'s. The return value is the
-`destination` object.
-
-### merge(destination, source, false)
-
-Defines `source`'s descriptors on `destination` if `destination` does not have
-a descriptor by the same name. The return value is the `destination` object.
+Merge properties from `source` object into `destination` object, preserving each property's descriptors.  If `overwrite == false` then existing properties on `destination` will not be overwritten.  The default value of `overwrite` is true.  Returns the destination object.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@
 [![Build Status][travis-image]][travis-url]
 [![Test Coverage][coveralls-image]][coveralls-url]
 
-Merge source object properties onto a destination object, and preserve 
-descriptors. Descriptors are configuration data associated to each property 
-such as whether the property is `writable`, `enumerable`, and/or `configurable`.
-This data will be preserved in the destination object.
+Merge source object "own" properties onto a destination object, including 
+non-enumerable "own" properties, and preserve each property's descriptors. 
+Descriptors are configuration data associated to each property such as whether 
+the property is `writable`, `enumerable`, and/or `configurable`.  This data 
+will be preserved in the destination object.
 
 ```js
 var thing = {
@@ -30,11 +31,12 @@ animal.name === 'jon'
 
 ### merge(destination, source, overwrite)
 
-Merge properties from `source` object onto `destination` object, preserving 
-each property's descriptors. The `overwrite` argument is optional and has 
-default value `true`. If `overwrite == true` then existing properties on 
-`destination` will be overwritten. If `overwrite == false`, existing properties 
-on `destination` will not be overwritten. Returns the destination object.
+Merge all "own" properties from `source` object onto `destination` object, 
+including non-enumerable "own" properties, preserving each property's descriptors. 
+The `overwrite` argument is optional and has default value `true`. If 
+`overwrite == true` then existing properties on `destination` will be overwritten. 
+If `overwrite == false`, existing properties on `destination` will not be 
+overwritten. Returns the destination object.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 [![Build Status][travis-image]][travis-url]
 [![Test Coverage][coveralls-image]][coveralls-url]
 
-Merge source object properties onto a destination object, and preserve descriptors.  Descriptors are configuration data associated to each property such as whether the property is `writable`, `enumerable`, and/or `configurable`.  This data will be preserved in the destination object.
+Merge source object properties onto a destination object, and preserve 
+descriptors. Descriptors are configuration data associated to each property 
+such as whether the property is `writable`, `enumerable`, and/or `configurable`.
+This data will be preserved in the destination object.
 
 ```js
 var thing = {
@@ -25,9 +28,13 @@ animal.name === 'jon'
 
 ## API
 
-### merge(Object destination, Object source [, bool overwrite])
+### merge(destination, source, overwrite)
 
-Merge properties from `source` object into `destination` object, preserving each property's descriptors.  If `overwrite == false` then existing properties on `destination` will not be overwritten.  The default value of `overwrite` is true.  Returns the destination object.
+Merge properties from `source` object onto `destination` object, preserving 
+each property's descriptors. The `overwrite` argument is optional and has 
+default value `true`. If `overwrite == true` then existing properties on 
+`destination` will be overwritten. If `overwrite == false`, existing properties 
+on `destination` will not be overwritten. Returns the destination object.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Merge source object "own" properties onto a destination object, including 
 non-enumerable "own" properties, and preserve each property's values and 
 descriptors. This means the destination object has a true copy of the source 
-object's properties, including their values and configuration.  In particular this 
+object's properties, including their values and configuration. In particular this 
 also copies over properties that are defined using a getter or a getter-setter 
 pair.
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@
 [![Test Coverage][coveralls-image]][coveralls-url]
 
 Merge source object "own" properties onto a destination object, including 
-non-enumerable "own" properties, and preserve each property's descriptors. 
-Descriptors are configuration data associated to each property such as whether 
-the property is `writable`, `enumerable`, and/or `configurable`.  This data 
-will be preserved in the destination object.
+non-enumerable "own" properties, and preserve each property's values and 
+descriptors. This means the destination object has a true copy of the source 
+object's properties, including their values and configuration.  In particular this 
+also copies over properties that are defined using a getter or a getter-setter 
+pair.
 
 ```js
 var thing = {
@@ -31,8 +32,7 @@ animal.name === 'jon'
 
 ### merge(destination, source, overwrite)
 
-Merge all "own" properties from `source` object onto `destination` object, 
-including non-enumerable "own" properties, preserving each property's descriptors. 
+Merge "own" properties from `source` object onto `destination` object. 
 The `overwrite` argument is optional and has default value `true`. If 
 `overwrite == true` then existing properties on `destination` will be overwritten. 
 If `overwrite == false`, existing properties on `destination` will not be 


### PR DESCRIPTION
As it is, the readme file on this repo is unclear on exactly what the library does.  For one thing, an object does not have descriptors.  It has properties, and the properties have descriptors.  I tried to make it clearer.