### PR TITLE
Chore/Include the installation instruction on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ merge(animal, thing)
 
 animal.name === 'jon'
 ```
+## Installation
+
+This is a [Node.js](https://nodejs.org/en/) module available through the
+[npm registry](https://www.npmjs.com/).
+
+
+Installation is done using the
+[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):
+
+```console
+$ npm install merge-descriptors
+```
 
 ## API
 


### PR DESCRIPTION
This PR will allow the npm package users to be able to get the instruction on how to install this package, This is not currently provided on the README.md file.